### PR TITLE
Roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,45 @@ https://youtu.be/7Ww_tTDrtio
 
 #### Will Not Do
 
+### Roles
+#### Team Member
+User will see only the contacts, groups, and other posts that are either assigned to their team 
+or directly shared with them.
 
+**Permissions:**
+- Create/View/Update/Assign contacts assigned to team/self
+- Create/View/Update groups assigned to team/self
+- Create/View/Update trainings assigned to team/self
+- List users
+- List teams
+
+#### Team Collaborator
+User can see all of the contacts, groups, and other post types in the system. 
+This allows them to communicate between teams and assign contacts to additional teams when needed. 
+On their list view, they have a quick filter to view just those posts that are assigned to their 
+team or any other team.
+
+**Permissions:**
+- All Team Member permissions (above)
+- View/Update/Assign any access contacts
+- View/Update any groups
+- View/Update any trainings
+
+#### Team Leader
+User can see all of the contacts, groups, and other post types in the system.
+User can see all teams but can only edit their own.
+
+**Permissions:**
+- All Team Collaborator permissions (above)
+- View any teams
+- Update own teams
+
+#### Teams Admin
+User can access and edit all post types, including creating and updating all teams.
+
+**Permissions:**
+- All Team Leader permissions (above)
+- Create/View/Update any teams
 
 ## Requirements
 

--- a/post-type/module-base.php
+++ b/post-type/module-base.php
@@ -125,7 +125,7 @@ class Disciple_Tools_Team_Module_Base extends DT_Module_Base {
             ];
         }
 
-        if( !isset( $expected_roles['team_leader'] ) ) {
+        if ( !isset( $expected_roles['team_leader'] ) ){
             $expected_roles['team_leader'] = [
                 'label' => __( 'Team Leader', 'disciple-tools-team-module' ),
                 'description' => 'Access to all Contacts, Groups, etc. for all teams and access to update their team',

--- a/post-type/module-base.php
+++ b/post-type/module-base.php
@@ -85,75 +85,54 @@ class Disciple_Tools_Team_Module_Base extends DT_Module_Base {
     public function dt_set_roles_and_permissions( $expected_roles ){
         $multiplier_permissions = Disciple_Tools_Roles::default_multiplier_caps(); // get the base multiplier permissions
 
+
+        $base_team_member_permissions = wp_parse_args( [
+            'dt_list_users' => true,
+            'access_specific_teams' => true, //give user permission to all posts their team(s) are assigned to
+            'assign_any_contacts' => true, //assign contacts to others,
+            'access_trainings' => true,
+            'create_trainings' => true,
+            'update_trainings' => true,
+            'access_teams' => true,
+        ], $multiplier_permissions );
+
+
+        $general_team_admin_permissions = wp_parse_args( [
+            'dt_all_access_contacts' => true, //view and update all access contacts
+
+            'view_any_groups' => true,
+            'update_any_groups' => true,
+
+            'view_any_trainings' => true,
+            'update_any_trainings' => true,
+        ], $base_team_member_permissions );
+
         if ( !isset( $expected_roles['team_member'] ) ){
             $expected_roles['team_member'] = [
 
                 'label' => __( 'Team Member', 'disciple-tools-team-module' ),
                 'description' => 'Interacts with Contacts, Groups, etc., for a given team',
-                'permissions' => wp_parse_args( [
-                    'dt_list_users' => true,
-                    'access_specific_teams' => true,
-                    'assign_any_contacts' => true, //assign contacts to others,
-                    'access_trainings' => true,
-                    'create_trainings' => true,
-                    'access_teams' => true,
-                ], $multiplier_permissions ),
+                'permissions' => $base_team_member_permissions,
             ];
         }
 
-        if ( !isset( $expected_roles['team_collaborator'] ) ) {
+        if ( !isset( $expected_roles['team_collaborator'] ) ){
             $expected_roles['team_collaborator'] = [
                 'label' => __( 'Team Collaborator', 'disciple-tools-team-module' ),
                 'description' => 'Access to all Contacts, Groups, etc. for all teams',
-                'permissions' => wp_parse_args( [
-                    'dt_list_users' => true,
-                    // 'dt_all_access_contacts' => true,
-                    'access_contacts' => true,
-                    'view_any_contacts' => true,
-                    'update_any_contacts' => true,
-                    'assign_any_contacts' => true, //assign contacts to others,
-
-                    'access_groups' => true,
-                    'view_any_groups' => true,
-                    'update_any_groups' => true,
-
-                    'access_trainings' => true,
-                    'view_any_trainings' => true,
-                    'update_any_trainings' => true,
-                    'create_trainings' => true,
-
-                    // 'access_teams' => true,
-                    // 'view_any_teams' => true,
-
-                ], $multiplier_permissions ),
+                'permissions' => wp_parse_args( [], $general_team_admin_permissions ),
                 'order' => 20
             ];
         }
 
-        if ( !isset( $expected_roles['team_leader'] ) ) {
+        if( !isset( $expected_roles['team_leader'] ) ) {
             $expected_roles['team_leader'] = [
                 'label' => __( 'Team Leader', 'disciple-tools-team-module' ),
                 'description' => 'Access to all Contacts, Groups, etc. for all teams and access to update their team',
                 'permissions' => wp_parse_args( [
-                    'dt_list_users' => true,
-                    'dt_all_access_contacts' => true,
-                    'access_contacts' => true,
-                    'assign_any_contacts' => true, //assign contacts to others,
-
-                    'access_groups' => true,
-                    'view_any_groups' => true,
-                    'update_any_groups' => true,
-
-                    'access_trainings' => true,
-                    'view_any_trainings' => true,
-                    'update_any_trainings' => true,
-                    'create_trainings' => true,
-
-                    'access_teams' => true,
                     'view_any_teams' => true,
                     'update_my_teams' => true,
-
-                ], $multiplier_permissions ),
+                ], $general_team_admin_permissions ),
                 'order' => 20
             ];
         }
@@ -163,28 +142,17 @@ class Disciple_Tools_Team_Module_Base extends DT_Module_Base {
                 'label' => __( 'Teams Admin', 'disciple-tools-team-module' ),
                 'description' => 'Admin access to all teams',
                 'permissions' => wp_parse_args( [
-                    'dt_all_access_contacts' => true,
                     'view_project_metrics' => true,
                     'list_users' => true,
-                    'dt_list_users' => true,
-                    'assign_any_contacts' => true, //assign contacts to others
-                    'access_teams' => true,
+
                     'create_teams' => true,
                     'view_any_teams' => true,
                     'update_any_teams' => true,
-                ], $multiplier_permissions ),
+                ], $general_team_admin_permissions ),
                 'order' => 20
             ];
         }
 
-        // if the user can access contact they also can access this post type
-        // foreach ( $expected_roles as $role => $role_value ){
-        //     if ( isset( $expected_roles[$role]['permissions']['access_contacts'] ) && $expected_roles[$role]['permissions']['access_contacts'] ){
-        //         $expected_roles[$role]['permissions']['access_' . $this->post_type ] = true;
-        //         $expected_roles[$role]['permissions']['create_' . $this->post_type] = true;
-        //         $expected_roles[$role]['permissions']['update_' . $this->post_type] = true;
-        //     }
-        // }
 
         // Only admins can view/update the teams post type
         if ( isset( $expected_roles['administrator'] ) ){

--- a/post-type/module-base.php
+++ b/post-type/module-base.php
@@ -93,11 +93,11 @@ class Disciple_Tools_Team_Module_Base extends DT_Module_Base {
             'access_trainings' => true,
             'create_trainings' => true,
             'update_trainings' => true,
-            'access_teams' => true,
+            'list_all_teams' => true,
         ], $multiplier_permissions );
 
 
-        $general_team_admin_permissions = wp_parse_args( [
+        $general_all_teams_permissions = wp_parse_args( [
             'dt_all_access_contacts' => true, //view and update all access contacts
 
             'view_any_groups' => true,
@@ -109,7 +109,6 @@ class Disciple_Tools_Team_Module_Base extends DT_Module_Base {
 
         if ( !isset( $expected_roles['team_member'] ) ){
             $expected_roles['team_member'] = [
-
                 'label' => __( 'Team Member', 'disciple-tools-team-module' ),
                 'description' => 'Interacts with Contacts, Groups, etc., for a given team',
                 'permissions' => $base_team_member_permissions,
@@ -120,7 +119,7 @@ class Disciple_Tools_Team_Module_Base extends DT_Module_Base {
             $expected_roles['team_collaborator'] = [
                 'label' => __( 'Team Collaborator', 'disciple-tools-team-module' ),
                 'description' => 'Access to all Contacts, Groups, etc. for all teams',
-                'permissions' => wp_parse_args( [], $general_team_admin_permissions ),
+                'permissions' => wp_parse_args( [], $general_all_teams_permissions ),
                 'order' => 20
             ];
         }
@@ -130,9 +129,10 @@ class Disciple_Tools_Team_Module_Base extends DT_Module_Base {
                 'label' => __( 'Team Leader', 'disciple-tools-team-module' ),
                 'description' => 'Access to all Contacts, Groups, etc. for all teams and access to update their team',
                 'permissions' => wp_parse_args( [
+                    'access_teams' => true,
                     'view_any_teams' => true,
                     'update_my_teams' => true,
-                ], $general_team_admin_permissions ),
+                ], $general_all_teams_permissions ),
                 'order' => 20
             ];
         }
@@ -143,12 +143,12 @@ class Disciple_Tools_Team_Module_Base extends DT_Module_Base {
                 'description' => 'Admin access to all teams',
                 'permissions' => wp_parse_args( [
                     'view_project_metrics' => true,
-                    'list_users' => true,
 
+                    'access_teams' => true,
                     'create_teams' => true,
                     'view_any_teams' => true,
                     'update_any_teams' => true,
-                ], $general_team_admin_permissions ),
+                ], $general_all_teams_permissions ),
                 'order' => 20
             ];
         }
@@ -356,7 +356,7 @@ class Disciple_Tools_Team_Module_Base extends DT_Module_Base {
 
             $can_view_single = current_user_can( 'access_specific_teams' ) && count( $user_team_ids ) === 1;
             $can_view_any = current_user_can( 'view_any_' . $post_type ) || current_user_can( 'dt_all_access_' . $post_type );
-            if ( !$can_view_single ) {
+            if ( !$can_view_single || $can_view_any ) {
 
                 foreach ( $team_counts as $team_id => $team_count ) {
                     $can_view_team = $can_view_any || array_search( $team_id, $user_team_ids ) > -1;
@@ -390,7 +390,7 @@ class Disciple_Tools_Team_Module_Base extends DT_Module_Base {
             // if has permission access_specific_teams and user.teams matches
         } else {
             //give user permission to all posts their team(s) are assigned to
-            if ( current_user_can( 'access_specific_teams' ) ) {
+            if ( !current_user_can( "view_any_$post_type" ) && current_user_can( 'access_specific_teams' ) ) {
                 $team_ids = self::get_user_teams();
 
                 $permissions[] = [ 'teams' => $team_ids ];


### PR DESCRIPTION
In this PR:
- Let Collaborator assign contacts to teams.
- Give base team permissions to all team roles.
- Use same base admin permissions for all admin roles.
- using `dt_all_access_contacts` instead of `view_any_contact`

I'm not sure about team admin having access to all contacts or all "access" contacts
It seams that admins should have access to all "team" contacts.
But this does give team admin the permissions to keep things going.


