### PR TITLE
Fix permissions when a user has no teams

### DIFF
--- a/post-type/module-base.php
+++ b/post-type/module-base.php
@@ -424,8 +424,9 @@ class Disciple_Tools_Team_Module_Base extends DT_Module_Base {
             //give user permission to all posts their team(s) are assigned to
             if ( current_user_can( 'access_specific_teams' ) ) {
                 $team_ids = self::get_user_teams();
-
-                $permissions[] = [ 'teams' => $team_ids ];
+                if ( !empty( $team_ids ) ){
+                    $permissions[] = [ 'teams' => $team_ids ];
+                }
             }
         }
         return $permissions;


### PR DESCRIPTION
`$permissions[] = [ 'teams' => [] ];`
When the array is empty it means: get all contacts that don't have a team connection.
So if a user has the team member role, but they are not added to a team. Then they get access to all contact that are not part of a team.

I'm adding that documentation here: 
https://developers.disciple.tools/theme-core/api-posts/list-query#connection
